### PR TITLE
packages: improve isolation and cleanup

### DIFF
--- a/.github/workflows/bins.yaml
+++ b/.github/workflows/bins.yaml
@@ -89,12 +89,12 @@ jobs:
       package: nnc
     secrets:
       token: ${{ secrets.HUB_JWT }}
-  tpm:
-    uses: ./.github/workflows/bin-package-18.04.yaml
-    with:
-      package: tpm
-    secrets:
-      token: ${{ secrets.HUB_JWT }}
+  # tpm:
+  #   uses: ./.github/workflows/bin-package-18.04.yaml
+  #   with:
+  #     package: tpm
+  #   secrets:
+  #     token: ${{ secrets.HUB_JWT }}
   qsfs:
     uses: ./.github/workflows/bin-package-no-tag.yaml
     with:

--- a/bins/bins-extra.sh
+++ b/bins/bins-extra.sh
@@ -271,7 +271,7 @@ exclude_libs() {
 
 github_name() {
     # force github print
-    echo "name=${1}" >> $GITHUB_OUTPUT
+    echo "name=${1}-amd64-z4" >> $GITHUB_OUTPUT
     echo "[+] github exported name: ${1}"
 }
 

--- a/bins/bins-extra.sh
+++ b/bins/bins-extra.sh
@@ -263,6 +263,7 @@ exclude_libs() {
     echo "[+] excluding host critical libs"
     rm -rf ${ROOTDIR}/usr/lib/ld-linux*
     rm -rf ${ROOTDIR}/usr/lib/libc.*
+    rm -rf ${ROOTDIR}/usr/lib/libm.*
     rm -rf ${ROOTDIR}/usr/lib/libdl.*
     rm -rf ${ROOTDIR}/usr/lib/librt.*
     rm -rf ${ROOTDIR}/usr/lib/libresolv.*

--- a/bins/bins-extra.sh
+++ b/bins/bins-extra.sh
@@ -264,6 +264,8 @@ exclude_libs() {
     rm -rf ${ROOTDIR}/usr/lib/ld-linux*
     rm -rf ${ROOTDIR}/usr/lib/libc.*
     rm -rf ${ROOTDIR}/usr/lib/libdl.*
+    rm -rf ${ROOTDIR}/usr/lib/librt.*
+    rm -rf ${ROOTDIR}/usr/lib/libresolv.*
     rm -rf ${ROOTDIR}/usr/lib/libpthread.*
 }
 


### PR DESCRIPTION
### Description

Packages release from zos-v3 out-of-box is not secure enough and produce build which are overwriting critical system libraries. This was okay on zos-v3 because libraries were the same between packages and base image, but this is not true anymore.

### Changes

- Improve libraries exclusion (`librt`, `libresolv`, `libm`)
- Append `-amd64-z4` to package name to make it distinct
- Exclude package `tpm` to be built for now, this package include way too much libraries which are overwritten on the host and should not.

