### PR TITLE
exclude devices labeled zospxe while booting

### DIFF
--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -53,7 +53,7 @@ func (p *btrfsPool) Device() DeviceInfo {
 }
 
 func (p *btrfsPool) prepare() error {
-	p.name = p.device.Label
+	p.name = p.device.UUID
 	if p.device.Used() {
 		// device already have filesystem
 		return nil

--- a/pkg/storage/filesystem/device.go
+++ b/pkg/storage/filesystem/device.go
@@ -57,6 +57,7 @@ type DeviceInfo struct {
 	Filesystem FSType       `json:"fstype"`
 	Rota       bool         `json:"rota"`
 	Subsystems string       `json:"subsystems"`
+	UUID       string       `json:"uuid"`
 	Children   []DeviceInfo `json:"children,omitempty"`
 }
 
@@ -168,7 +169,7 @@ func (l *lsblkDeviceManager) lsblk(ctx context.Context) ([]DeviceInfo, error) {
 	args := []string{
 		"--json",
 		"-o",
-		"PATH,NAME,SIZE,SUBSYSTEMS,FSTYPE,LABEL,ROTA",
+		"PATH,NAME,SIZE,SUBSYSTEMS,FSTYPE,LABEL,ROTA,UUID",
 		"--bytes",
 		"--exclude",
 		"1,2,11",

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -36,8 +36,6 @@ const (
 	cacheGrowPercent   = 60
 	cacheShrinkPercent = 20
 	cacheCheckDuration = 5 * time.Minute
-
-	PXELABEL = "ZOSPXE"
 )
 
 var (
@@ -201,7 +199,7 @@ func (s *Module) mountPool(device filesystem.DeviceInfo, vm bool) {
 	log.Debug().Str("path", device.Path).Msg("mounting device")
 
 	if device.IsPXEPartition() {
-		log.Error().Str("device", device.Path).Msg("device has 'zospxe' label")
+		log.Info().Str("device", device.Path).Msg("device has 'ZOSPXE' label")
 		s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: fmt.Errorf("device is a PXE partition")})
 		return
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -36,6 +36,8 @@ const (
 	cacheGrowPercent   = 60
 	cacheShrinkPercent = 20
 	cacheCheckDuration = 5 * time.Minute
+
+	PXELABEL = "ZOSPXE"
 )
 
 var (
@@ -226,6 +228,13 @@ func (s *Module) initialize(ctx context.Context) error {
 
 	for _, device := range devices {
 		log.Debug().Msgf("device: %+v", device)
+
+		if device.Label == PXELABEL {
+			log.Error().Err(err).Str("device", device.Path).Msg("device has 'zospxe' label")
+			s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
+			continue
+		}
+
 		pool, err := filesystem.NewBtrfsPool(device)
 		if err != nil {
 			log.Error().Err(err).Str("device", device.Path).Msg("failed to create pool on device")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -197,6 +197,53 @@ func (s *Module) poolType(pool filesystem.Pool, vm bool) (zos.DeviceType, error)
 	return typ, nil
 }
 
+func (s *Module) mountPool(device filesystem.DeviceInfo, vm bool) {
+	log.Debug().Str("path", device.Path).Msg("mounting device")
+
+	if device.IsPXEPartition() {
+		log.Error().Str("device", device.Path).Msg("device has 'zospxe' label")
+		s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: fmt.Errorf("device is a PXE partition")})
+		return
+	}
+
+	pool, err := filesystem.NewBtrfsPool(device)
+	if err != nil {
+		log.Error().Err(err).Str("device", device.Path).Msg("failed to create pool on device")
+		s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
+		return
+	}
+
+	_, err = pool.Mount()
+	if err != nil {
+		log.Error().Err(err).Str("device", device.Path).Msg("failed to mount pool")
+		s.brokenPools = append(s.brokenPools, pkg.BrokenPool{Label: pool.Name(), Err: err})
+		return
+	}
+
+	usage, err := pool.Usage()
+	if err != nil {
+		log.Error().Err(err).Str("pool", pool.Name()).Str("device", device.Path).Msg("failed to get usage of pool")
+	}
+
+	typ, err := s.poolType(pool, vm)
+	if err != nil {
+		log.Error().Str("device", device.Path).Err(err).Msg("failed to get device type")
+		s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
+		return
+	}
+
+	switch typ {
+	case zos.SSDDevice:
+		s.totalSSD += usage.Size
+		s.ssds = append(s.ssds, pool)
+	case zos.HDDDevice:
+		s.totalHDD += usage.Size
+		s.hdds = append(s.hdds, pool)
+	default:
+		log.Error().Str("type", string(typ)).Str("device", device.Path).Msg("unknown device type")
+	}
+}
+
 /*
 *
 initialize, must be called at least onetime each boot.
@@ -229,47 +276,13 @@ func (s *Module) initialize(ctx context.Context) error {
 	for _, device := range devices {
 		log.Debug().Msgf("device: %+v", device)
 
-		if device.Label == PXELABEL {
-			log.Error().Err(err).Str("device", device.Path).Msg("device has 'zospxe' label")
-			s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
+		if len(device.Children) != 0 {
+			for _, part := range device.Children {
+				s.mountPool(part, vm)
+			}
 			continue
 		}
-
-		pool, err := filesystem.NewBtrfsPool(device)
-		if err != nil {
-			log.Error().Err(err).Str("device", device.Path).Msg("failed to create pool on device")
-			s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
-			continue
-		}
-
-		_, err = pool.Mount()
-		if err != nil {
-			log.Error().Err(err).Str("device", device.Path).Msg("failed to mount pool")
-			s.brokenPools = append(s.brokenPools, pkg.BrokenPool{Label: pool.Name(), Err: err})
-			continue
-		}
-		usage, err := pool.Usage()
-		if err != nil {
-			log.Error().Err(err).Str("pool", pool.Name()).Str("device", device.Path).Msg("failed to get usage of pool")
-		}
-
-		typ, err := s.poolType(pool, vm)
-		if err != nil {
-			log.Error().Str("device", device.Path).Err(err).Msg("failed to get device type")
-			s.brokenDevices = append(s.brokenDevices, pkg.BrokenDevice{Path: device.Path, Err: err})
-			continue
-		}
-
-		switch typ {
-		case zos.SSDDevice:
-			s.totalSSD += usage.Size
-			s.ssds = append(s.ssds, pool)
-		case zos.HDDDevice:
-			s.totalHDD += usage.Size
-			s.hdds = append(s.hdds, pool)
-		default:
-			log.Error().Str("type", string(typ)).Str("device", device.Path).Msg("unknown device type")
-		}
+		s.mountPool(device, vm)
 	}
 
 	log.Info().


### PR DESCRIPTION
### Description
- make storaged aware of disks partitions
- exclude devices (disk/partition) labeled zospxe while booting
- use UUID instead of LABEL for better identification for partitions

### Related Issues
- https://github.com/threefoldtech/zos/issues/2506

### Testing
- modify one of the newly created qcow2 disk images with qemu from the `vm.sh` script
```bash
# connect to the disk
sudo qemu-nbd --connect=/dev/nbd0 vdb.qcow2

# partition with `fdisk` [100mb, rest of space]
fdisk /dev/nbd0 

# format the disks 
sudo mkfs.vfat -n ZOSPXE /dev/nbd0p1
sudo mkfs.btrfs  /dev/nbd0p2

# schema should be like this
 ✗ lsblk -o NAME,FSTYPE,LABEL,MOUNTPOINT /dev/nbd0
NAME     FSTYPE LABEL  MOUNTPOINT
nbd0
├─nbd0p1 vfat   ZOSPXE
└─nbd0p2 btrfs

# disconnect
sudo qemu-nbd --disconnect /dev/nbd0

```

- expected in `zinit log storaged`
  - reading children
  - mounting children `vdb1/vdb2` not parent `vdb`
  - skipping any disk/partition has `ZOSPXE` label

![image](https://github.com/user-attachments/assets/decf409d-4494-42b5-8564-ee181df13178)
  
