### PR TITLE
secure farmer lan

### DIFF
--- a/cmds/modules/netlightd/main.go
+++ b/cmds/modules/netlightd/main.go
@@ -132,7 +132,7 @@ func action(cli *cli.Context) error {
 	}
 
 	if err := nft.DropTrafficToLAN(); err != nil {
-		return errors.New("failed to drop traffic to lan")
+		return fmt.Errorf("failed to drop traffic to lan: %w", err)
 	}
 
 	mod, err := netlight.NewNetworker()

--- a/cmds/modules/netlightd/main.go
+++ b/cmds/modules/netlightd/main.go
@@ -131,6 +131,10 @@ func action(cli *cli.Context) error {
 		return fmt.Errorf("failed to setup mycelium on host: %w", err)
 	}
 
+	if err := nft.DropTrafficToLAN(); err != nil {
+		return errors.New("failed to drop traffic to lan")
+	}
+
 	mod, err := netlight.NewNetworker()
 	if err != nil {
 		return fmt.Errorf("failed to create Networker: %w", err)

--- a/pkg/netlight/nft/nft.go
+++ b/pkg/netlight/nft/nft.go
@@ -1,10 +1,14 @@
 package nft
 
 import (
+	"fmt"
 	"io"
+	"log/slog"
+	"net"
 	"os/exec"
 
 	"github.com/rs/zerolog/log"
+	"github.com/vishvananda/netlink"
 
 	"github.com/pkg/errors"
 )
@@ -31,4 +35,48 @@ func Apply(r io.Reader, ns string) error {
 		return errors.Wrap(err, "failed to execute nft")
 	}
 	return nil
+}
+
+// DropTrafficToLAN drops all the outgoing traffic to any peers on
+// the same lan network
+func DropTrafficToLAN() error {
+	mac, err := getDefaultGwMac()
+	slog.Info("returned", "mac", mac.String(), "err", err)
+	return nil
+}
+
+func getDefaultGwMac() (net.HardwareAddr, error) {
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list routes: %v", err)
+	}
+
+	var defaultRoute *netlink.Route
+	for _, route := range routes {
+		if route.Dst == nil {
+			defaultRoute = &route
+			break
+		}
+	}
+
+	if defaultRoute == nil {
+		return nil, fmt.Errorf("default route not found")
+	}
+
+	if defaultRoute.Gw == nil {
+		return nil, fmt.Errorf("default route has no gateway")
+	}
+
+	neighs, err := netlink.NeighList(0, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list neighbors: %v", err)
+	}
+
+	for _, neigh := range neighs {
+		if neigh.IP.Equal(defaultRoute.Gw) {
+			return neigh.HardwareAddr, nil
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/netlight/nft/nft.go
+++ b/pkg/netlight/nft/nft.go
@@ -37,6 +37,9 @@ func Apply(r io.Reader, ns string) error {
 }
 
 func applyNftRule(rule []string) error {
+	if len(rule) == 0 {
+		return errors.New("invalid nft rule")
+	}
 	cmd := exec.Command(rule[0], rule[1:]...)
 
 	out, err := cmd.CombinedOutput()

--- a/util.go
+++ b/util.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/threefoldtech/zos4/pkg/netlight/nft"
-
-func main() {
-	nft.DropTrafficToLAN()
-}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/threefoldtech/zos4/pkg/netlight/nft"
+
+func main() {
+	nft.DropTrafficToLAN()
+}


### PR DESCRIPTION
### Description
- block traffic to other nodes on the same lan by dropping packets to the default gateway
- except the ports for myc/ygg peer discovery

### Limitation
- this only protect the lan network, if a node behind a natted network. devices in the outer network will still be access able

### Tested
- run two nodes with qemu connected to the same interface on host
- deploy a vm on node1
- pinging node2 from the vm should be dropped