### PR TITLE
farmer security fix

### DIFF
--- a/pkg/netlight/nft/nft.go
+++ b/pkg/netlight/nft/nft.go
@@ -64,14 +64,20 @@ func DropTrafficToLAN() error {
 	var buf bytes.Buffer
 	buf.WriteString("table inet filter {\n")
 	buf.WriteString("  chain forward {\n")
+	// allow traffic on sport ygg/myc discovery ports
 	buf.WriteString("    meta l4proto { tcp, udp } @th,0,16 { 9651, 9650 } accept;\n")
+	// allow traffic on dport ygg/myc discovery ports
 	buf.WriteString("    meta l4proto { tcp, udp } @th,16,16 { 9651, 9650 } accept;\n")
+	// allow traffic to the default gateway
 	buf.WriteString(fmt.Sprintf("    ip daddr %s accept;\n", ipAddr))
+	// allow traffic to any ip not in the network range
 	buf.WriteString(fmt.Sprintf("    ip daddr != %s accept;\n", netAddr))
+	// only drop traffic if it destined to mac addr other than the default gateway
 	buf.WriteString(fmt.Sprintf("    ether daddr != %s drop;\n", macAddr))
 	buf.WriteString("  }\n")
 	buf.WriteString("}\n")
 
+	// applied on host
 	return Apply(&buf, "")
 }
 


### PR DESCRIPTION
### Description
- apply the nft rules if only the default gw is private
- explicitly allow traffic to all ips except the default gw network
- except the router from the lan block
- create a buffer with rules instead of executing commands
- use the nft.Apply function for executing the buffer

### Related issues
- https://github.com/threefoldtech/zos/issues/2455

### Test
- run two nodes with qemu connected to the same interface on host
- deploy a vm on node1
- pinging node2 from the vm should be dropped