### PR TITLE
Update rfs/zos-config URLs after repo renames

### DIFF
--- a/bins/packages/rfs/rfs.sh
+++ b/bins/packages/rfs/rfs.sh
@@ -2,8 +2,8 @@ RFS_VERSION_V1="1.1.1"
 RFS_VERSION_V2="2.0.6"
 RFS_CHECKSUM_V1="974b8dc45ae9c1b00238a79b0f4fc9de"
 RFS_CHECKSUM_V2="9e37743dfe94b4577ccf90c573c07638"
-RFS_LINK_V1="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V1}/rfs"
-RFS_LINK_V2="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V2}/rfs"
+RFS_LINK_V1="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V1}/rfs"
+RFS_LINK_V2="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V2}/rfs"
 
 download_rfs() {
     download_file ${RFS_LINK_V1} ${RFS_CHECKSUM_V1} rfs-${RFS_VERSION_V1}

--- a/bootstrap/bootstrap/src/hub.rs
+++ b/bootstrap/bootstrap/src/hub.rs
@@ -15,7 +15,7 @@ struct ZosConfig {
 }
 
 fn get_hub_url(runmode: &RunMode) -> Result<Vec<String>> {
-    let base_url = "https://github.com/threefoldtech/zos-config/raw/main/";
+    let base_url = "https://github.com/threefoldtech/zos_config/raw/main/";
     let config_filename = match runmode {
         RunMode::Prod => "production.json",
         RunMode::Dev => "development.json",

--- a/scripts/debug_image.md
+++ b/scripts/debug_image.md
@@ -49,7 +49,7 @@ NOTE:
 
 - [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor): hypervisor that booting the machine
 - [virtiofsd](https://gitlab.com/muhamad.azmy/virtiofsd/): used to share a host directory for the rootfs. we are using a forked version
-- [rfs v1](https://github.com/threefoldtech/rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
+- [rfs v1](https://github.com/threefoldtech/zos_rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
 - `overlayfs`: mounts a read-write layer on the rootfs
 
 ## Script Walkthrough
@@ -101,7 +101,7 @@ NOTE:
 - **rfs**
 
   ```bash
-  wget https://github.com/threefoldtech/rfs/releases/download/v1.1.1/rfs
+  wget https://github.com/threefoldtech/zos_rfs/releases/download/v1.1.1/rfs
   chmod +x ./rfs
 
   sudo ln -s $(realpath ./rfs) /usr/local/bin/rfs1

--- a/scripts/debug_image.sh
+++ b/scripts/debug_image.sh
@@ -106,7 +106,7 @@ check_or_install_deps() {
     fi
 
     if ! command -v rfs1 &>/dev/null; then
-        wget https://github.com/threefoldtech/rfs/releases/download/v1.1.1/rfs
+        wget https://github.com/threefoldtech/zos_rfs/releases/download/v1.1.1/rfs
         chmod +x rfs
         sudo ln -s $(realpath ./rfs) /usr/local/bin/rfs1
     fi


### PR DESCRIPTION
Points download/runtime URLs at the new repo names instead of relying on GitHub's non-permanent rename redirects.

- `rfs` -> `zos_rfs`: `bins/packages/rfs/rfs.sh`, `scripts/debug_image.sh` (+ doc)
- `zos-config` -> `zos_config`: `bootstrap/bootstrap/src/hub.rs` (runtime config fetch)

Verified rfs v1.1.1/v2.0.6 and the zos_config runmode files return 200 from the new URLs. No functional change.

Scope: P0 only — does NOT touch the Go module deps (zosbase/tfchain/tfgrid-sdk-go), which are the separate module-path migration.

Part of the repo-rename migration off GitHub redirects.