### PR TITLE
fix(mycelium): update stale md5 checksum for v0.6.1 asset

### DIFF
--- a/bins/packages/mycelium/mycelium.sh
+++ b/bins/packages/mycelium/mycelium.sh
@@ -1,5 +1,5 @@
 MYCELIUM_VERSION="0.6.1"
-MYCELIUM_CHECKSUM="160f367228ff6a8a933ff0a55209d010"
+MYCELIUM_CHECKSUM="db532d4d7e0d975ee7e8128bdc9ad8b9"
 MYCELIUM_LINK="https://github.com/threefoldtech/mycelium/releases/download/v${MYCELIUM_VERSION}/mycelium-x86_64-unknown-linux-musl.tar.gz"
 
 download_mycelium() {


### PR DESCRIPTION
`mycelium / builder` fails with `[-] checksum mismatch`. The `mycelium v0.6.1` release asset was re-uploaded upstream, so its md5 no longer matches the pinned `MYCELIUM_CHECKSUM`.

- stale: `160f367228ff6a8a933ff0a55209d010`
- current asset: `db532d4d7e0d975ee7e8128bdc9ad8b9` (sha256 `cfc50c3e57b29991209e7233585c484cc2552e8e1abd512c6727f94d30fb1ad6`, 7393527 bytes)

Pre-existing, **unrelated to the repo-rename migration**.

> `virtwhat / builder` is separate — its source `git.annexia.org` returns HTTP 503 (down); needs a reliable mirror, not a checksum change. Not addressed here.